### PR TITLE
Supabase Sql File Updates

### DIFF
--- a/src/supabase/db.sql
+++ b/src/supabase/db.sql
@@ -12,6 +12,18 @@ SET row_security = off;
 
 CREATE SCHEMA IF NOT EXISTS "public";
 
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_extension
+        WHERE extname = 'vector'
+    ) THEN
+        CREATE EXTENSION vector
+        SCHEMA extensions;
+    END IF;
+END $$;
+
 ALTER SCHEMA "public" OWNER TO "pg_database_owner";
 
 CREATE OR REPLACE FUNCTION "public"."check_similarity_and_insert"(query_table_name text, query_user_id uuid, query_user_ids uuid[], query_content jsonb, query_room_id uuid, query_embedding extensions.vector, similarity_threshold double precision) RETURNS void


### PR DESCRIPTION
Vector Extensions are not defaulted enabled in supabase. Instead of making the user manually add them, this will enable vectors prior to creating all tables. If vectors are already enabled, it will skip this and move on.